### PR TITLE
Positivity zscore tests

### DIFF
--- a/tests/data/cleaned_data/positivity_zscore_chats.csv
+++ b/tests/data/cleaned_data/positivity_zscore_chats.csv
@@ -1,0 +1,11 @@
+conversation_num,speaker_nickname,message,expected_column,expected_value
+I,1,I am enjoying the weather today!,positivity_zscore_chats,1.4346980995217895
+I,2,Likewise it's beautiful.,positivity_zscore_chats,1.3862275774841195
+I,3,I'm not a fan of the rain.,positivity_zscore_chats,-1.1105762978767422
+I,1,I think it's enchanting.,positivity_zscore_chats,1.3393376638185834
+I,3,Agree to disagree.,positivity_zscore_chats,-1.0295558496422406
+J,1,This conversation is more neutral.,positivity_zscore_chats,-0.4050742076501151
+J,2,How are you doing?,positivity_zscore_chats,-0.613670825442067
+J,3,I am mainly studying today.,positivity_zscore_chats,-0.7371504869897708
+J,1,Anything fun planned?,positivity_zscore_chats,0.5057873469055534
+J,3,Mostly a trip to the library.,positivity_zscore_chats,-0.77002302012911

--- a/tests/data/cleaned_data/test_chat_level.csv
+++ b/tests/data/cleaned_data/test_chat_level.csv
@@ -734,3 +734,13 @@ H,3,trying quote random,dale_chall_classification,easy
 H,3,erase eraser errand every even dig dim dime dine computer,dale_chall_classification,medium
 H,3,discover direction different,dale_chall_classification,easy
 H,4,even this is magnificent! even this is magnificent!,dale_chall_classification,difficult
+I,1,I am enjoying the weather today!,positivity_zscore_conversation,0.855868
+I,2,Likewise it's beautiful.,positivity_zscore_conversation,0.8156
+I,3,I'm not a fan of the rain.,positivity_zscore_conversation,-1.2577
+I,1,I think it's enchanting.,positivity_zscore_conversation,0.7766
+I,3,Agree to disagree.,positivity_zscore_conversation,-1.19044
+J,1,This conversation is more neutral.,positivity_zscore_conversation,-0.002217
+J,2,How are you doing?,positivity_zscore_conversation,-0.443621
+J,3,I am mainly studying today.,positivity_zscore_conversation,-0.704912
+J,1,Anything fun planned?,positivity_zscore_conversation,1.925224
+J,3,Mostly a trip to the library.,positivity_zscore_conversation,-0.774473

--- a/tests/data/cleaned_data/test_chat_level.csv
+++ b/tests/data/cleaned_data/test_chat_level.csv
@@ -744,3 +744,8 @@ J,2,How are you doing?,positivity_zscore_conversation,-0.443621
 J,3,I am mainly studying today.,positivity_zscore_conversation,-0.704912
 J,1,Anything fun planned?,positivity_zscore_conversation,1.925224
 J,3,Mostly a trip to the library.,positivity_zscore_conversation,-0.774473
+K,1,This is the same text.,positivity_zscore_conversation,
+K,1,This is the same text.,positivity_zscore_conversation,
+K,1,This is the same text.,positivity_zscore_conversation,
+K,1,This is the same text.,positivity_zscore_conversation,
+K,1,This is the same text.,positivity_zscore_conversation,

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -29,8 +29,27 @@ if __name__ == "__main__":
 	test_forward_flow_df = pd.read_csv("data/cleaned_data/fflow.csv", encoding=chat_encoding['encoding'])
 	conv_complex_timestamps_df = pd.read_csv("data/cleaned_data/test_conv_level_complex_timestamps.csv", encoding=chat_encoding['encoding'])
 
+	positivity_zscore = pd.read_csv("data/cleaned_data/positivity_zscore_chats.csv", encoding=chat_encoding['encoding'])
+
 		
 	# TESTING DATASETS -------------------------------
+
+	test_positivity = FeatureBuilder(
+		input_df = positivity_zscore,
+		vector_directory = "./vector_data/",
+		output_file_path_chat_level = "./output/chat/test_positivity_chat_level.csv",
+		output_file_path_user_level = "./output/user/test_positivity_user_level.csv",
+		output_file_path_conv_level = "./output/conv/test_positivity_conv_level.csv",
+		custom_features = [ # these require vect_data, so they now need to be explicitly included in order to calculate them
+			"(BERT) Mimicry",
+			"Moving Mimicry",
+			"Forward Flow",
+			"Discursive Diversity"
+		],
+		turns = False,
+		regenerate_vectors = True
+	)
+	test_positivity.featurize()
 
 	testing_chat = FeatureBuilder(
 		input_df = chat_df,

--- a/tests/test_feature_metrics.py
+++ b/tests/test_feature_metrics.py
@@ -8,7 +8,8 @@ import itertools
 
 test_chat_df = pd.read_csv("./output/chat/test_chat_level_chat.csv")
 test_info_exchange_zscore_df = pd.read_csv("./output/chat/info_exchange_zscore_chats.csv")
-test_chat_df = pd.concat([test_chat_df, test_info_exchange_zscore_df], axis=0)
+test_pos = pd.read_csv("./output/chat/test_positivity_chat_level.csv")
+test_chat_df = pd.concat([test_chat_df, test_info_exchange_zscore_df, test_pos], axis=0)
 test_conv_df = pd.read_csv("./output/conv/test_conv_level_conv.csv")
 test_chat_complex_df = pd.read_csv(
     "./output/chat/test_chat_level_chat_complex.csv")

--- a/tests/test_feature_metrics.py
+++ b/tests/test_feature_metrics.py
@@ -58,22 +58,26 @@ def test_chat_unit_equality(row):
     # if expected_column doesn't exist in tested_features, add an entry for it
     if row[1]['expected_column'] not in tested_features:
         tested_features[row[1]['expected_column']] = {'passed': 0, 'failed': 0}
-
-    try:
-        if (type(actual) == str):
-            assert actual == expected
-        else:
-            assert round(float(actual), 3) == round(float(expected), 3)
-        tested_features[row[1]['expected_column']]['passed'] += 1
-    except AssertionError:
-        tested_features[row[1]['expected_column']]['failed'] += 1
-        with open('test.log', 'a') as file:
-            file.write("\n")
-            file.write("------TEST FAILED------\n")
-            file.write(
-                f"Testing {row[1]['expected_column']} for message: {row[1]['message_original']}\n")
-            file.write(f"Expected value: {expected}\n")
-            file.write(f"Actual value: {actual}\n")
+        try:
+            if (pd.isnull(actual) and pd.isnull(expected)):
+                assert True
+            elif (type(actual) == str):
+                # file.write("both are strings")
+                assert actual == expected
+            else:
+                # file.write("both are numbers")
+                assert round(float(actual), 3) == round(float(expected), 3)
+            tested_features[row[1]['expected_column']]['passed'] += 1
+        except AssertionError:
+            
+            tested_features[row[1]['expected_column']]['failed'] += 1
+            with open('test.log', 'a') as file:
+                file.write("\n")
+                file.write("------TEST FAILED------\n")
+                file.write(
+                    f"Testing {row[1]['expected_column']} for message: {row[1]['message_original']}\n")
+                file.write(f"Expected value: {expected}\n")
+                file.write(f"Actual value: {actual}\n")
 
 
 test_ner = pd.read_csv('./output/chat/test_named_entity_chat_level.csv')

--- a/tests/test_feature_metrics.py
+++ b/tests/test_feature_metrics.py
@@ -62,10 +62,8 @@ def test_chat_unit_equality(row):
             if (pd.isnull(actual) and pd.isnull(expected)):
                 assert True
             elif (type(actual) == str):
-                # file.write("both are strings")
                 assert actual == expected
             else:
-                # file.write("both are numbers")
                 assert round(float(actual), 3) == round(float(expected), 3)
             tested_features[row[1]['expected_column']]['passed'] += 1
         except AssertionError:


### PR DESCRIPTION
_Pull Request Template_:
If you are merging in a feature or other major change, use this template to check your pull request!

# Basic Info
What's this pull request about? 
positivity_zscore_chats and positivity_zscore_conversation tests
added line in test_feature_metrics to account for nan outputs as well

# My PR Adds or Improves Documentation
If your feature is about documentation, ensure that you check the boxes relevant to you.

## Docstrings
- [ ] Docstrings: I have followed the proper documentation format (https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html; Google Format recommended).
- [ ] Docstrings: Every function in the file has a block quote comment with a description of the feature.
- [ ] Docstrings: Every input argument is documented.
- [ ] Docstrings: The output type is documented, along with a description of what the output is for.
- [ ] Docstrings: I have linked the feature under the Table of Contents (docs/source/features/index.rst)

## Feature Wiki
- [ ] Conceptual Wiki: I made a copy of the TEMPLATE (docs/source/features_conceptual/TEMPLATE.rst)
- [ ] Conceptual Wiki: I replaced the word TEMPLATE at the top of the file with the name of the feature (.. _TEMPLATE:) Please do NOT delete any of the punctuation (the `.._` and `:`) in the header, as this is important for referencing the feature in the Table of Contents!
- [ ] Conceptual Wiki: I have answered the six sections of the template to the best of my ability.
- [ ] Conceptual Wiki: I have linked the feature under the Table of Contents (docs/source/features_conceptual/index.rst).

## General Documentation
- [ ] My documentation is linked in a toctree.
- [ ] I have confirmed that `make clean` and `make html` do not generate breaking errors.

# My PR is About Adding a New Feature to the Code Repository

## Adding Feature to the Feature Dictionary
- [ ] I have edited the `feature_dictionary.py` file with an appropriate entry for my feature. Below is a sample entry; *I confirm that all fields are accurately filled out*.

```
  "Function Word Accommodation": {
    "columns": ["function_word_accommodation"],
    "file": "./features/word_mimicry.py",
    "level": "Chat",
    "semantic_grouping": "Variance",
    "description": "The total number of function words used in a given turn that were also used in the previous turn. Function words are defined as a list of 190 words from the source paper.",
    "references": "(Ranganath et al., 2013)",
    "wiki_link": "https://github.com/Watts-Lab/team-process-map/wiki/C.9-Mimicry:-Function-word,-Content-word,-BERT,-Moving",
    "function": ChatLevelFeaturesCalculator.calculate_word_mimicry,
    "dependencies": [],
    "preprocess": [],
    "vect_data": False,
    "bert_sentiment_data": False
  }
```
- [ ] If my feature is at the chat level, my dictionary entry is in the top half of the file; if my feature is at the conversation level, my dictionary entry is in the bottom half of the file (below the comment that says, `### Conversation Level`).

## Documentation
Did you document your feature? You should follow the same requirements as above:
- [ ] Docstrings: I have followed the proper documentation format (https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html; Google Format recommended).
- [ ] Docstrings: Every function in the file has a block quote comment with a description of the feature.
- [ ] Docstrings: Every input argument is documented.
- [ ] Docstrings: The output type is documented, along with a description of what the output is for.
- [ ] Docstrings: I have linked the feature under the Table of Contents (docs/source/features/index.rst)

## Code Basics
- [ ] My feature is a .py file.
- [ ] My feature uses snake case in the name. That means the name of the format is `my_feature`, NOT `myFeature` (camel case).
- [ ] My feature has the name, `NAME_features.py`, where NAME is the name of my feature.
- [ ] My feature is located in `src/features/`.

## Testing
- [x] I have thought about test cases for my features, with inputs and expected outputs.
- [x] I have added test cases for my feature under the `tests/` folder.
- [x] My feature passes the automated testing suite.

The location of my tests are here:
> [PASTE LINK HERE]

If you check all the boxes above, then you ready to merge!
