### PR TITLE
Release 0.1.6 hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "team_comm_tools"
-version = "0.1.5"
+version = "0.1.6"
 requires-python = ">= 3.10"
 dependencies = [
   "chardet>=3.0.4",

--- a/src/team_comm_tools/utils/preprocess.py
+++ b/src/team_comm_tools/utils/preprocess.py
@@ -173,9 +173,19 @@ def preprocess_naive_turns(chat_data, column_names):
     conversation_id_col = column_names['conversation_id_col']
     message_col = column_names['message_col']
     speaker_id_col = column_names['speaker_id_col']
-    turn_id_per_conv = chat_data.groupby([conversation_id_col], sort=False).apply(lambda df : get_turn_id(df, speaker_id_col))
-    turn_id_per_conv = turn_id_per_conv.to_frame().reset_index().rename(columns={0:'turn_id'})
-    chat_data = pd.concat([chat_data, turn_id_per_conv["turn_id"]], axis=1)
+    turn_id_per_conv = (
+        chat_data.groupby([conversation_id_col], sort=False)
+        .apply(lambda df : get_turn_id(df, speaker_id_col))
+        .reset_index(level=0, drop=True)  # Ensures long format
+    )
+    if len(chat_data[conversation_id_col].unique()) == 1:
+        turn_id_per_conv = turn_id_per_conv.T
+    else:
+        turn_id_per_conv = turn_id_per_conv.to_frame()
+    turn_id_per_conv = turn_id_per_conv.rename(columns={0:'turn_id'})
+    turn_id_per_conv["turn_id"] = turn_id_per_conv["turn_id"].astype(str)
+    # chat_data = pd.concat([chat_data, turn_id_per_conv["turn_id"]], axis=1)
+    chat_data = chat_data.merge(turn_id_per_conv, left_index=True, right_index=True, how="left") # merge with index to preserve order
     
     # Use turn_id to compress messages with the same turn id per conversation
     chat_data = chat_data.groupby(conversation_id_col, sort=False).apply(
@@ -217,6 +227,7 @@ def compress(turn_df, message_col):
     if (len(turn_df) > 1):
         result[message_col] = turn_df[message_col].str.cat(sep=' ')
         result['message_lower_with_punc'] = turn_df['message_lower_with_punc'].str.cat(sep=' ')
+        result[message_col + "_original"] = turn_df[message_col + "_original"].str.cat(sep=' ')
     return result
 
 def create_cumulative_rows(input_df, conversation_id, timestamp_col, grouping_keys, within_task = False):

--- a/tests/data/cleaned_data/test_turns.csv
+++ b/tests/data/cleaned_data/test_turns.csv
@@ -1,0 +1,16 @@
+conversation_num,speaker_nickname,message,timestamp
+I,A,How are you doing?,1
+I,B,Likewise it's beautiful.,2
+I,A,I'm not a fan of the rain.,3
+I,A,It's way too cold!,4
+I,B,Agree to disagree.,5
+I,B,I love the magical mist.,6
+I,B,I think it's enchanting.,7
+J,A,Hey --,1
+J,A,How are you doing?,2
+J,B,I am mainly studying today.,3
+J,B,It's not a fun day.,4
+J,B,I'm taking a trip to the library because I have an exam.,5
+I,B,I love to dance in the rain.,8
+I,B,Sunshine is boring.,9
+I,B,Rainy days should not go away.,10

--- a/tests/run_package_grouping_tests.py
+++ b/tests/run_package_grouping_tests.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
 
 	tiny_multi_task_renamed_df = pd.read_csv("data/cleaned_data/multi_task_TINY_cols_renamed.csv", encoding='utf-8')
 	package_agg_df = pd.read_csv("data/cleaned_data/test_package_aggregation.csv", encoding='utf-8')
+	df_test_turn_concat = pd.read_csv("data/cleaned_data/test_turns.csv")
 
 	"""
 	Testing Package Task 1
@@ -276,3 +277,15 @@ if __name__ == "__main__":
 		assert('has unhashable data types' in str(e)) # make sure we caught the right error!
 		print("Test has properly exited with error.")
 
+	"""
+	Test that running with turns = True works as expected.
+	"""
+	turn_concat_tester = FeatureBuilder(
+		input_df = df_test_turn_concat,
+		conversation_id_col = "conversation_num",
+		speaker_id_col = "speaker_nickname",
+		message_col = "message",
+		output_file_base = "turns_concat_output", # Naming output files using the output_file_base parameter (recommended)
+		turns = True
+	)
+	turn_concat_tester.featurize()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -21,6 +21,8 @@ custom_agg_conv = pd.read_csv('./output/conv/custom_agg_test_conv_level.csv')
 custom_agg_user = pd.read_csv('./output/user/custom_agg_test_user_level.csv')
 custom_no_agg_conv = pd.read_csv('./output/conv/custom_agg_test_no_agg_conv_level.csv')
 custom_no_agg_user = pd.read_csv('./output/user/custom_agg_test_no_agg_user_level.csv')
+turn_concatenation = pd.read_csv('./output/turn/turns_concat_output_turn_level.csv')
+turn_concatenation_conv = pd.read_csv('./output/conv/turns_concat_output_conv_level.csv')
 
 # Import the Feature Dictionary
 from team_comm_tools.feature_dict import feature_dict
@@ -308,4 +310,23 @@ def test_custom_aggregation_turned_off():
             file.write(f"Default aggregated columns are NOT the only aggregated columns present in the dataframe when aggregations are off.\n")
 
         raise
-    
+
+def test_turn_concatenation():
+
+    try:
+        # ensure that all successive utterances by speaker B in conversation I are concatenated
+        conversation_i = turn_concatenation[turn_concatenation["conversation_num"]=="I"]
+        last_utterance = conversation_i.tail(1)["message_original"].values
+        assert(last_utterance == "Agree to disagree. I love the magical mist. I think it's enchanting. I love to dance in the rain. Sunshine is boring. Rainy days should not go away.")
+
+        # assert that turn_taking_index is always 1
+        turn_taking_index = turn_concatenation_conv["turn_taking_index"]
+        assert(set(turn_taking_index) == {1})
+
+    except AssertionError:
+        with open('test.log', 'a') as file:
+            file.write("\n")
+            file.write("------TEST FAILED------\n")
+            file.write(f"Concatenating successive columns with turns = True failed.\n")
+
+        raise


### PR DESCRIPTION
# Change log

Fixes issues related to concatenation of turns:
- Turns = True leads to error in case of only one conversation num
- Turns = True did not properly update message_original
- Turns = True did not have tests.

All 3 are now resolved.